### PR TITLE
fix timeouts caused by spotify API changes

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -74,4 +74,5 @@ app.use(router);
 router.get("/**", proxy.get);
 router.post("/**", proxy.post);
 
+router.get("/color-lyrics/v2/track/:id", lyrics.get);
 router.get("/color-lyrics/v2/track/:id/**", lyrics.get);

--- a/src/app.ts
+++ b/src/app.ts
@@ -74,4 +74,4 @@ app.use(router);
 router.get("/**", proxy.get);
 router.post("/**", proxy.post);
 
-router.get("/color-lyrics/v2/track/:id", lyrics.get);
+router.get("/color-lyrics/v2/track/:id/**", lyrics.get);

--- a/src/fetchers.ts
+++ b/src/fetchers.ts
@@ -54,9 +54,13 @@ async function getLyricsFromDB(track_id: string) {
 	}
 }
 
-async function getSpotifyLyrics(id: string, market: string) {
+async function getSpotifyLyrics(id: string, market: string, image_url: string | null = null) {
+	const url = image_url 
+		? `https://spclient.wg.spotify.com/color-lyrics/v2/track/${id}/image/${encodeURIComponent(image_url)}?format=json&vocalRemoval=false&market=${market}`
+		: `https://spclient.wg.spotify.com/color-lyrics/v2/track/${id}?format=json&vocalRemoval=false&market=${market}`;
+	
 	const lyrics = await fetch(
-		`https://spclient.wg.spotify.com/color-lyrics/v2/track/${id}?format=json&vocalRemoval=false&market=${market}`,
+		url,
 		{
 			headers: {
 				"app-platform": "WebPlayer",
@@ -246,6 +250,7 @@ export async function fetchLyrics(
 	market: string,
 	setEnv: Record<string, any>,
 	authorization: string | null,
+	image_url: string | null = null
 ) {
 	env = setEnv;
 
@@ -257,7 +262,7 @@ export async function fetchLyrics(
 
 	const lyricsFetchers = [
 		() => getLyricsFromDB(track_id),
-		() => getSpotifyLyrics(track_id, market),
+		() => getSpotifyLyrics(track_id, market, image_url),
 		() => getNeteaseLyrics(track_id),
 		() => getLRCLibLyrics(track_id),
 	];

--- a/src/functions/lyrics.ts
+++ b/src/functions/lyrics.ts
@@ -6,6 +6,9 @@ export default {
 		const track_id = event.context.params?.id;
 		if (!track_id) throw createError({ status: 400 });
 
+		const path_match = event.path.match(/\/track\/[^/]+\/image\/(.+)$/);
+		const image_url = path_match ? decodeURIComponent(path_match[1]) : null;
+
 		const query = getQuery(event);
 
 		let market = "US";
@@ -23,6 +26,7 @@ export default {
 			market,
 			event.context.cloudflare?.env || process.env,
 			event.headers.get("authorization"),
+			image_url
 		);
 		if (!lyrics_buffer) {
 			setHeader(event, "Cache-Control", "no-store");

--- a/src/functions/lyrics.ts
+++ b/src/functions/lyrics.ts
@@ -6,7 +6,7 @@ export default {
 		const track_id = event.context.params?.id;
 		if (!track_id) throw createError({ status: 400 });
 
-		const path_match = event.path.match(/\/track\/[^/]+\/image\/(.+)$/);
+		const path_match = event.path.match(/\/image\/(.+)$/);
 		const image_url = path_match ? decodeURIComponent(path_match[1]) : null;
 
 		const query = getQuery(event);

--- a/vercel.json
+++ b/vercel.json
@@ -5,7 +5,8 @@
     "outputDirectory": "api",
     "functions": {
         "api/vercel.ts": {
-            "runtime": "@vercel/node@3.2.14"
+            "runtime": "@vercel/node@3.2.14",
+            "maxDuration": 60
         }
     },
     "rewrites": [


### PR DESCRIPTION
Spotify API now requires album image URL in some requests (format: /track/:id/image/:imageUrl)
As a result the vercel app responds with timeouts, this PR fixes the issues, I tested it on vercel and it seems to work, not sure about other deplyment methods, I did not bother testing them

## Résumé par Sourcery

Cette pull request corrige les timeouts rencontrés lors de la récupération des paroles depuis l'API Spotify. Le problème était causé par des changements récents de l'API Spotify qui incluent des données d'image dans la requête. Les modifications mettent à jour l'endpoint des paroles pour gérer correctement les URLs d'image, résolvant ainsi le problème de timeout.

Corrections de bugs :
- Corrige les timeouts lors de la récupération des paroles depuis l'API Spotify en raison des changements dans l'API liés aux images.

Améliorations :
- Met à jour l'endpoint des paroles pour gérer les URLs d'image, permettant à l'application de récupérer les paroles même lorsque des données d'image sont incluses dans la requête.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

This pull request addresses timeouts experienced when fetching lyrics from the Spotify API. The issue was caused by recent changes to the Spotify API that include image data in the request. The changes modify the lyrics endpoint to correctly handle image URLs, resolving the timeout issue.

Bug Fixes:
- Fixes timeouts when fetching lyrics from the Spotify API due to changes in the API related to images.

Enhancements:
- Updates the lyrics endpoint to handle image URLs, allowing the app to fetch lyrics even when image data is included in the request.

</details>